### PR TITLE
Fix #13: Enhance log message and make it conditional

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,8 +39,10 @@ func main() {
 	config := parseFlags()
 	repoWithOrg, error := getRepo(config)
 	if error != nil {
-		fmt.Print(error)
-		println("Check 'gh auth status'. You may need to run 'gh config set git_protocol ssh'.")
+		fmt.Println(error)
+		if strings.Contains(error.Error(), "none of the git remotes configured for this repository point to a known GitHub host") {
+			println("If current folder is related to a GitHub repository, please check 'gh auth status' and 'gh config list'.")
+		}
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Only log the "Check 'gh auth status'..." message if none of the git remotes
configured for this repository point to a known GitHub host.

Also add a trailing line.

It prevents this kind of log:

	failed to run git: fatal: not a git repository (or any of the parent directories): .git
	. error: exit status 128Check 'gh auth status'. You may need to run 'gh config set git_protocol ssh'.

Log example:

	$ cd transparence-sante # a git repo from gitlab.com
	$ gh collab-scanner
	unable to determine current repository, none of the git remotes configured for this repository point to a known GitHub host
	If current folder is related to a GitHub repository, please check 'gh auth status' and 'gh config list'.