### PR TITLE
Get commit via `--version` flag 🏷

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ gh-collab-scanner --help
 
 ## Develop 🧑‍💻
 
+Requires Go 1.18 or later.
+
 ### Build from source code 🧑‍💻▶️
 
 Build then run:

--- a/main_test.go
+++ b/main_test.go
@@ -181,3 +181,10 @@ func TestScanCommunityScore_Verbose(t *testing.T) {
 
 	assert.Equal(t, "  - a community profile score of 42 💯", message)
 }
+
+func TestVersion(t *testing.T) {
+	version := getVersion()
+
+	assert.NotEmpty(t, version.commit)
+	assert.NotEmpty(t, version.date)
+}


### PR DESCRIPTION
If code is "dirty" (i.e. git working tree is not clean):

	gh collab-scanner --version
	Commit 5f2f41a89baf8b200f489683e8a1e3f336b45973 (2022-03-16 05:36:30 +0000 UTC) (dirty)

If code is "clean" (i.e. git working tree is clean):

	gh collab-scanner --version
	Commit d5e9419cf611902420316318442f33bb44d2a37a (2022-03-22 05:33:04 +0000 UTC)