### PR TITLE
Fix bug #21: Hide "HTTP 404" for community profile score if forked repository

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ type repo struct {
 	Description string
 	Topics      []string
 	Visibility  string
+	Fork		bool
 }
 
 type collaborator struct {
@@ -96,7 +97,7 @@ func main() {
 			fmt.Printf(repoMessage)
 			collaboratorsMessage := scanCollaborators(config, repoWithOrg)
 			fmt.Printf(collaboratorsMessage)
-			if strings.Compare(repo.Visibility, "public") == 0 {
+			if !repo.Fork && strings.Compare(repo.Visibility, "public") == 0 {
 				communityScoreMessage := scanCommunityScore(config, repoWithOrg)
 				fmt.Printf(communityScoreMessage)
 			}
@@ -180,6 +181,7 @@ func scanRepo(config config, repoWithOrg string) (message string, repository rep
 		Description string
 		Topics      []string
 		Visibility  string
+		Fork		bool
 	}{}
 	errRepo := client.Get(
 		"repos/"+repoWithOrg,
@@ -226,13 +228,13 @@ func scanCollaborators(config config, repoWithOrg string) string {
 		if config.verbose {
 			message = message + fmt.Sprintf("  - %d collaborator 👤", len(collaborators))
 		} else {
-			message = message + fmt.Sprintf("%d collaborator 👤 ", len(collaborators))
+			message = message + fmt.Sprintf("%d collaborator 👤", len(collaborators))
 		}
 	} else {
 		if config.verbose {
 			message = message + fmt.Sprintf("  - %d collaborators 👥", len(collaborators))
 		} else {
-			message = message + fmt.Sprintf("%d collaborators 👥 ", len(collaborators))
+			message = message + fmt.Sprintf("%d collaborators 👥", len(collaborators))
 		}
 	}
 	return message

--- a/main_test.go
+++ b/main_test.go
@@ -140,7 +140,7 @@ func TestScanCollaborators(t *testing.T) {
 
 	message := scanCollaborators(config{repo: "acme/buzz"}, "acme/buzz")
 
-	assert.Equal(t, "1 collaborator 👤 ", message)
+	assert.Equal(t, "1 collaborator 👤", message)
 }
 
 func TestScanCollaborators_Verbose(t *testing.T) {


### PR DESCRIPTION

Before fix:

	$ go run main.go --repo nicokosi/gilded-rose-kata
	README ☑️, no topics 😇, 1 collaborator 👤
	HTTP 404: Not Found (https://api.github.com/repos/nicokosi/gilded-rose-kata/community/profile)%

Now:

	$ go run main.go --repo nicokosi/gilded-rose-kata
	README ☑️, no topics 😇, 1 collaborator 👤