### PR TITLE
Add a newline for non-verbose single repo 🧹

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 				communityScoreMessage := scanCommunityScore(config, repoWithOrg)
 				fmt.Printf(communityScoreMessage)
 			}
+			println()
 		}
 	}
 }


### PR DESCRIPTION
It prevents from displaying a '%' character on my ZSH terminal.
See ZSH PROMPT_SP option:
https://zsh.sourceforge.io/Doc/Release/Options.html

Before:

	README ☑️, topics ☑️, 1 collaborator 👤community profile score: 33 💯%

Now:

	README ☑️, topics ☑️, 1 collaborator 👤community profile score: 33 💯