### PR TITLE
Fix issue #40: Filter org/user repos by topic via new `-topic` flag #️⃣

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,14 +23,13 @@ type config struct {
 }
 
 func parseFlags() config {
-	repo := flag.String("repo", "", "a optional GitHub repository (i.e. 'python/peps') ; use repo for current folder if omitted and no 'org' nor 'user' flag")
-	org := flag.String("org", "", "a optional GitHub organization (i.e. 'python') to scan the repositories from (100 max) ; use repo for current folder if omitted and no 'repo' nor 'user' flag")
-	user := flag.String("user", "", "a optional GitHub user (i.e. 'torvalds') to scan the repositories from (100 max); use repo for current folder if omitted and no 'repo' nor 'org' flag")
-	topic := flag.String("topic", "", "an optional GitHub topic (i.e. 'testing') to filter the repositories ; ignored if no '--user' nor '--org' flag")
-
-	page := flag.Int("page", 1, "Page number for 'repo' and 'user' flags, 100 repositories per page")
-	verbose := flag.Bool("verbose", false, "mode that outputs several lines (otherwise, outputs a one-liner) ; default: false")
-	version := flag.Bool("version", false, "Output version-related information")
+	org := flag.String("org", "", "an optional GitHub organization (i.e. 'python') to scan the repositories from (100 max) ; use repository for current folder if omitted and no '-repo' nor '-user' flag")
+	page := flag.Int("page", 1, "page number for '-repo' and '-user' flags, 100 repositories per page")
+	repo := flag.String("repo", "", "an optional GitHub repository (i.e. 'python/peps') ; use repository for current folder if omitted and no '-org' nor '-user' flag")
+	topic := flag.String("topic", "", "an optional GitHub topic (i.e. 'testing') to filter the repositories ; ignored if no '-user' nor '-org' flag")
+	user := flag.String("user", "", "an optional GitHub user (i.e. 'torvalds') to scan the repositories from (100 max) ; use repository for current folder if omitted and no '-repo' nor '-org' flag")
+	verbose := flag.Bool("verbose", false, "verbose mode outputs several lines per repository ; non-verbose mode outputs a one-liner per repository ; default: false")
+	version := flag.Bool("version", false, "outputs version-related information")
 	flag.Parse()
 	return config{*repo, *org, *user, *topic, *page, *verbose, *version}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -36,7 +36,35 @@ func TestGetRepos_for_org(t *testing.T) {
 
 	repositories, error := getRepos(config{org: "acme"})
 
-	assert.NotEmpty(t, repositories)
+	assert.Len(t, repositories, 2)
+	assert.Nil(t, error)
+}
+
+func TestGetRepos_for_org_with_topic(t *testing.T) {
+	defer gock.Off()
+	defer gock.DisableNetworking()
+	gock.New("https://api.github.com").
+		Get("/orgs/acme/repos").
+		Reply(200).
+		File("test_repos.json")
+
+	repositories, error := getRepos(config{org: "acme", topic: "rabbit"})
+
+	assert.Len(t, repositories, 1)
+	assert.Nil(t, error)
+}
+
+func TestGetRepos_for_org_with_missing_topic(t *testing.T) {
+	defer gock.Off()
+	defer gock.DisableNetworking()
+	gock.New("https://api.github.com").
+		Get("/orgs/acme/repos").
+		Reply(200).
+		File("test_repos.json")
+
+	repositories, error := getRepos(config{org: "acme", topic: "does-not-exist"})
+
+	assert.Empty(t, repositories)
 	assert.Nil(t, error)
 }
 
@@ -50,7 +78,35 @@ func TestGetRepos_for_user(t *testing.T) {
 
 	repositories, error := getRepos(config{user: "acme"})
 
-	assert.NotEmpty(t, repositories)
+	assert.Len(t, repositories, 2)
+	assert.Nil(t, error)
+}
+
+func TestGetRepos_for_user_with_topic(t *testing.T) {
+	defer gock.Off()
+	defer gock.DisableNetworking()
+	gock.New("https://api.github.com").
+		Get("/users/acme/repos").
+		Reply(200).
+		File("test_repos.json")
+
+	repositories, error := getRepos(config{user: "acme", topic: "rabbit"})
+
+	assert.Len(t, repositories, 1)
+	assert.Nil(t, error)
+}
+
+func TestGetRepos_for_user_with_missing_topic(t *testing.T) {
+	defer gock.Off()
+	defer gock.DisableNetworking()
+	gock.New("https://api.github.com").
+		Get("/users/acme/repos").
+		Reply(200).
+		File("test_repos.json")
+
+	repositories, error := getRepos(config{user: "acme", topic: "does-not-exist"})
+
+	assert.Empty(t, repositories)
 	assert.Nil(t, error)
 }
 

--- a/test_repos.json
+++ b/test_repos.json
@@ -1,7 +1,11 @@
 [
     {
-        "fullName": "Bug Bunny"
-    },
+        "fullName": "Bug Bunny",
+        "topics": [
+            "rabbit",
+            "cartoon"
+          ]
+        },
     {
         "fullName": "Coyote"
     }


### PR DESCRIPTION
Introduce flag `--topic` to filter repositories scanned via the `--org` or
`--user` flag.

Examples:

- `gh collab-scanner --org pytest-dev` scans 62 repositories.

- `gh collab-scanner --org pytest-dev --topic testing` scans 10
repositories.

- `gh collab-scanner --org pytest-dev --topic does-not-exist` scans 0
repositories.

See https://github.com/pytest-dev?q=%23testing.