### PR TITLE
Fix newlines between repos with `--user` or `--org` 🐛

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 					fmt.Print(communityScoreMessage)
 				}
 			}
-			println()
+			fmt.Println()
 		}
 	} else {
 		repoWithOrg, error := getRepo(config)
@@ -100,7 +100,7 @@ func main() {
 				communityScoreMessage := scanCommunityScore(config, repoWithOrg)
 				fmt.Print(communityScoreMessage)
 			}
-			println()
+			fmt.Println()
 		}
 	}
 }


### PR DESCRIPTION
Before this fix, newlines between multiple repositories were added to standard error instead of standard output. 😇

Thank you @Jin66! :hugs: 