### PR TITLE
Declare Go 1.18 in main Go module 🛠

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicokosi/gh-collab-scanner
 
-go 1.17
+go 1.18
 
 require github.com/cli/go-gh v0.0.3
 


### PR DESCRIPTION
Should have been added in commit 339065b1a8f49d7f9eaf4e72c8ab01fb54aac0d8. 😇

See the documentation, `Go Modules Reference`: https://go.dev/ref/mod#go-mod-file-go. 📖