### PR TITLE
Run CI and release with Go 1.22 🆙

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: Test 🧪
         run: go test -v -cover
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v1
         with:
-          go_version: "1.21"
+          go_version: "1.22"


### PR DESCRIPTION
Release note: https://go.dev/doc/go1.22
