### PR TITLE
Fix release enabling cgo 👷

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: cli/gh-extension-precompile@v1
         with:
           go_version: "1.22"
+        env:
+          CGO_ENABLED: 1


### PR DESCRIPTION
Enable cgo in order to fix 🤞 release which failed:

	Run cli/gh-extension-precompile@v1
	Run actions/setup-go@v3
	Setup go version spec 1.22

	✂️...✂️

	Run ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
	go: downloading github.com/cli/go-gh/v2 v2.5.0

    ✂️...✂️

	android/amd64 requires external (cgo) linking, but cgo is not enabled
	Error: Process completed with exit code 1.

See release job:
https://github.com/nicokosi/gh-collab-scanner/actions/runs/7897321092/job/21552756920

See the documention of "gh-extension-precompile" GitHub Action:
https://github.com/cli/gh-extension-precompile?tab=readme-ov-file#go-extensions

	To maximize portability of built products, this action builds Go binaries with cgo disabled. To override that, set the CGO_ENABLED environment variable:

	- uses: cli/gh-extension-precompile@v1
	  env:
	    CGO_ENABLED: 1
