### PR TITLE
Use default Go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/nicokosi/gh-collab-scanner
 
-go 1.21
-
-toolchain go1.22.0
+go 1.22
 
 require (
 	github.com/cli/go-gh/v2 v2.5.0


### PR DESCRIPTION
Toolchain visibly does not need to be changed.

We'll see if it fixes the current release issue. 🤷 https://github.com/cli/gh-extension-precompile/issues/50

See Toolchain documention:
https://go.dev/doc/toolchain