### PR TITLE
Try to fix release failure since `Go 1.22` upgrade 😅

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.21"
       - name: Test 🧪
         run: go test -v -cover
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v1
         with:
-          go_version: "1.22"
+          go_version: "1.21"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nicokosi/gh-collab-scanner
 
-go 1.22
+go 1.21
+
+toolchain go1.22.0
 
 require (
 	github.com/cli/go-gh/v2 v2.5.0


### PR DESCRIPTION
- **Revert "Use default Go toolchain"**
- **Revert "Run CI and release with Go 1.22 🆙"**
